### PR TITLE
Initiate default configuration on first run

### DIFF
--- a/zwavejs2mqtt/DOCS.md
+++ b/zwavejs2mqtt/DOCS.md
@@ -13,6 +13,7 @@ Some advantages and use-cases for this are:
   it is available for Home Assistant at the same time.
 - Allow [ESPHome.io][esphome] based ESP devices to directly respond or work
   with your Z-Wave network.
+- Pre-configures itself with the Mosquitto add-on when found.
 
 This add-on uses the [Zwavejs2Mqtt][zwavejs2mqtt] software.
 
@@ -55,10 +56,6 @@ To do this:
 1. Enter the following information:
    - Serial Port (e.g., `/dev/serial/by-id/usb-0658_0200_if00`)
    - Network Key (e.g., `2232666D100F795E5BB17F0A1BB7A146`)
-   - **Enable the WS Server** checkbox!
-
-You can check the "Disable Gateway" box for now, as you can set up MQTT
-later (if you like that is).
 
 Now click the "SAVE" button and navigate to the "Control Panel" in the menu.
 If you had devices paired already, you should see the showing up slowly.

--- a/zwavejs2mqtt/config.json
+++ b/zwavejs2mqtt/config.json
@@ -11,6 +11,7 @@
   "init": false,
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "discovery": ["zwave_js"],
+  "services": ["mqtt:want"],
   "auto_uart": true,
   "map": ["share:rw"],
   "schema": {

--- a/zwavejs2mqtt/rootfs/etc/cont-init.d/configuration.sh
+++ b/zwavejs2mqtt/rootfs/etc/cont-init.d/configuration.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: Z-Wave JS to MQTT
+# Creates store folder if it doesn't exists yet
+# ==============================================================================
+declare gateway
+declare host="core-mosquitto"
+declare mqtt
+declare password=""
+declare port="1883"
+declare username=""
+declare zwave
+
+if bashio::fs.directory_exists "/data/store"; then
+  bashio::exit.ok
+fi
+
+mkdir /data/store || bashio::exit.nok "Could not create data store."
+
+gateway=$(bashio::var.json \
+  "payloadType" "^0" \
+  "type" "^0" \
+  hassDiscovery "^false" \
+  logEnabled "^true" \
+  logLevel info \
+  logToFile "^false" \
+  nodeNames "^true" \
+)
+
+if bashio::services.available "mqtt"; then
+  host=$(bashio::services "mqtt" "host")
+  password=$(bashio::services "mqtt" "password")
+  port=$(bashio::services "mqtt" "port")
+  username=$(bashio::services "mqtt" "username")
+fi
+
+mqtt=$(bashio::var.json \
+  auth "^true" \
+  disabled "^true" \
+  host "${host}" \
+  name "Mosquitto Add-on" \
+  password "${password}" \
+  port "^${port}" \
+  username "${username}" \
+)
+
+zwave=$(bashio::var.json \
+  commandsTimeout "^30" \
+  logLevel info \
+  logToFile "^false" \
+  networkKey "" \
+  port "" \
+  serverEnabled "^true" \
+  serverPort "^3000" \
+)
+
+bashio::var.json \
+  gateway "^${gateway}" \
+  mqtt "^${mqtt}" \
+  zwave "^${zwave}" \
+  > /data/store/settings.json

--- a/zwavejs2mqtt/rootfs/etc/cont-init.d/configuration.sh
+++ b/zwavejs2mqtt/rootfs/etc/cont-init.d/configuration.sh
@@ -38,7 +38,7 @@ mqtt=$(bashio::var.json \
   auth "^true" \
   disabled "^true" \
   host "${host}" \
-  name "Mosquitto Add-on" \
+  name "Mosquitto" \
   password "${password}" \
   port "^${port}" \
   username "${username}" \

--- a/zwavejs2mqtt/rootfs/etc/cont-init.d/folders.sh
+++ b/zwavejs2mqtt/rootfs/etc/cont-init.d/folders.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/with-contenv bashio
-# ==============================================================================
-# Home Assistant Community Add-on: Z-Wave JS to MQTT
-# Creates store folder if it doesn't exists yet
-# ==============================================================================
-if ! bashio::fs.directory_exists "/data/store"; then
-  mkdir /data/store
-fi


### PR DESCRIPTION
# Proposed Changes

Initiates a default configuration on the first run.

If the Mosquitto add-on is found, it will also fetch service information for that add-on and pre-configure that as well.
