### PR TITLE
Ensure HA Discovery awaits for Z-Wave JS Server

### DIFF
--- a/zwavejs2mqtt/rootfs/etc/services.d/zwavejs2mqtt/discovery
+++ b/zwavejs2mqtt/rootfs/etc/services.d/zwavejs2mqtt/discovery
@@ -6,7 +6,7 @@
 declare payload
 
 # Wait for zwavejs2mqtt to be available
-bashio::net.wait_for 44920
+bashio::net.wait_for 3000 localhost 1800
 
 # Wait some more
 sleep 10


### PR DESCRIPTION
# Proposed Changes

This PR ensures the Discovery process waits for the Z-Wave JS process to become available.

The latest zwavejs2mqtt awaits for the driver to be ready before starting this process.
This means, we have to wait as well, or else the Home Assistant integration discovery flow will be silently aborted with an error.

## Related Issues

Upstream commit: <https://github.com/zwave-js/zwavejs2mqtt/commit/8c7249e2bb17161132663a258e71aff4d0d04b64>

