### PR TITLE
Upgrade zwavejs2mqtt to v1.0.1

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.15.4-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/a465c6c1197a05fd56732f0e309f8ba78f3d465d.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v1.0.1.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

zwavejs2mqtt is now 1.0.0

This upgrades the add-on to 1.0.1 and will now follow upstream releases.

- <https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v1.0.0>
- <https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v1.0.1>
