### PR TITLE
Optionally expose WS port

### DIFF
--- a/zwavejs2mqtt/config.json
+++ b/zwavejs2mqtt/config.json
@@ -16,5 +16,11 @@
   "map": ["share:rw"],
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?"
+  },
+  "ports": {
+    "3000/tcp": null
+  },
+  "ports_description": {
+    "3000/tcp": "Z-Wave JS communication"
   }
 }


### PR DESCRIPTION
# Proposed Changes

`zwave-js-server` has an option to expose the port outside the host. This is useful for developing because I can connect a client locally while keeping my HA instance up.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
