### PR TITLE
:arrow_up: Upgrades ZwaveJS2Mqtt to v1.1.0

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.15.4-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v1.0.5.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v1.1.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

Updates Z-Wave JS to MQTT to v1.1.0

Upstream release notes: <https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v1.1.0>
