### PR TITLE
Enable udev

### DIFF
--- a/zwavejs2mqtt/config.json
+++ b/zwavejs2mqtt/config.json
@@ -13,6 +13,7 @@
   "discovery": ["zwave_js"],
   "services": ["mqtt:want"],
   "uart": true,
+  "udev": true,
   "map": ["share:rw"],
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?"


### PR DESCRIPTION
# Proposed Changes

Enable the `udev` option on the add-on, so the control panel is capable of showing the serial devices by their alias paths (e.g., serial by-id paths).
