### PR TITLE
Allow Supervisor to use health check for watchdog

### DIFF
--- a/zwavejs2mqtt/config.json
+++ b/zwavejs2mqtt/config.json
@@ -12,7 +12,7 @@
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "discovery": ["zwave_js"],
   "services": ["mqtt:want"],
-  "watchdog": "http://[HOST]:44920/health/zwave",
+  "watchdog": "http://[HOST]:8099/health/zwave",
   "uart": true,
   "udev": true,
   "map": ["share:rw"],

--- a/zwavejs2mqtt/config.json
+++ b/zwavejs2mqtt/config.json
@@ -12,7 +12,7 @@
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "discovery": ["zwave_js"],
   "services": ["mqtt:want"],
-  "watchdog", "http://[HOST]:44920/health/zwave",
+  "watchdog": "http://[HOST]:44920/health/zwave",
   "uart": true,
   "udev": true,
   "map": ["share:rw"],

--- a/zwavejs2mqtt/config.json
+++ b/zwavejs2mqtt/config.json
@@ -12,6 +12,7 @@
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "discovery": ["zwave_js"],
   "services": ["mqtt:want"],
+  "watchdog", "http://[HOST]:44920/health/zwave",
   "uart": true,
   "udev": true,
   "map": ["share:rw"],


### PR DESCRIPTION
# Proposed Changes

Could by maybe usefully take the add-on down if the software has an issue with the driver?

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
