### PR TITLE
⬆️ Upgrades ZwaveJS2Mqtt to v2.0.0

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.16.0-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v1.2.3.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v2.0.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

Upgrades ZwaveJS2Mqtt to v2.0.0

Upstream release notes: <https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v2.0.0>
