### PR TITLE
⬆️ Upgrades ZwaveJS2Mqtt to v3.2.0

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.16.0-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v3.1.0.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v3.2.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

This PR is awaiting an upstream change/rectification of the release notes, as they contain information that is incorrect and untrue.

> It's since been worked out and was just a misunderstanding.

The add-on was removed because:

![image](https://user-images.githubusercontent.com/195327/113851155-7f83c800-979b-11eb-9dda-7674beeb8f71.png)

There was no misunderstanding in that.

CC @robertsLando @AlCalzone

Upstream release notes: <https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v3.2.0>
