### PR TITLE
⬆️ Upgrades Z-Wave JS Server to 1.10.0

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -30,6 +30,7 @@ RUN \
     && cd /opt \
     && yarn config set unsafe-perm \
     && yarn install --ignore-optional \
+    && yarn upgrade @zwave-js/server@1.10.0 \
     && yarn run build:server \
     && yarn run build:ui \
     && yarn install --production --ignore-optional \


### PR DESCRIPTION
# Proposed Changes

Temporary bumps Z-Wave JS server to guarantee compatibility with Home Assistant 2021.9.0b0