### PR TITLE
🚑 Increase yarn network timeout for more consistent builds

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -29,6 +29,7 @@ RUN \
     \
     && cd /opt \
     && yarn config set unsafe-perm \
+    && yarn config set network-timeout 1000000 \
     && yarn install --ignore-optional \
     && yarn run build:server \
     && yarn run build:ui \


### PR DESCRIPTION
# Proposed Changes

The builds of this add-on is often running towards network timeouts in yarn. This PR extends the timeout value to make it occur less often (and thus resulting in more consistent builds).
