### PR TITLE
Upgrades ZwaveJS2Mqtt to v5.7.2

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.17.6-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.7.1.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.7.2.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
Proposed Change:

https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v5.7.2
