### PR TITLE
bump zwavejs2mqtt to 5.9.0

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.17.6-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.8.0.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.9.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

Update [zwavejs2mqtt](https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v5.9.0) to 5.9.0