### PR TITLE
Upgrade ZwaveJS2Mqtt to v5.10.1

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.17.6-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.10.0.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.10.1.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \

--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.17.6-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.8.0.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.9.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \

--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.17.6-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.9.0.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.10.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \

--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -22,7 +22,7 @@ RUN \
         nodejs=14.17.6-r0 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.7.3.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v5.8.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

Upgrade ZwaveJS2Mqtt to v5.8.0

## Related Issues

https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v5.10.0
https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v5.9.0

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
