### PR TITLE
⬆️Update zwavejs2mqtt to 6.2.0

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -26,7 +26,7 @@ RUN \
     && npm install --global yarn@2.4.3 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v6.1.1.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v6.2.0.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

Update `zwavejs2mqtt` to 6.2.0. Motivated by zwavejs2mqtt 6.2.0 bumping `zwave-js` to 8.9.1. `zwave-js` 8.9.1 fixes a major bug (see links below). 

https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v6.2.0

## Related Issues

- https://github.com/zwave-js/zwavejs2mqtt/issues/2081
- https://community.home-assistant.io/t/all-controls-switches-shutters-etc-stop-working-after-a-while/362139/17
- https://community.home-assistant.io/t/z-wave-js-stopping-constantly/369395/38

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
