### PR TITLE
Fix upgrading firmware from Ingress

### DIFF
--- a/zwavejs2mqtt/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/zwavejs2mqtt/rootfs/etc/nginx/templates/ingress.gtpl
@@ -3,12 +3,12 @@ server {
 
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
+    proxy_set_header X-External-Path {{ .entry }};
 
     location / {
         allow   172.30.32.2;
         deny    all;
 
         proxy_pass http://backend;
-        proxy_set_header X-External-Path {{ .entry }};
     }
 }


### PR DESCRIPTION
Move "proxy_set_header X-External-Path" so that all proxy_set_header
options are defined at the same level. Fixes issue #51.

# Proposed Changes

I've done some digging and believe I've found the cause issue #51:

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header

"These directives are inherited from the previous configuration level if and only if there are no proxy_set_header directives defined on the current level."

It looks like that is causing this line (https://github.com/hassio-addons/addon-zwavejs2mqtt/blob/main/zwavejs2mqtt/rootfs/etc/nginx/templates/ingress.gtpl#L12) to prevent any of the `proxy_set_header` config from `include /etc/nginx/includes/proxy_params.conf;` from taking effect. Specifically, the two lines:

```
proxy_set_header Connection $connection_upgrade;
proxy_set_header Upgrade $http_upgrade
```

With the config in its current state, when starting a firmware upgrade (zwavejs2mqtt -> pick a node -> advanced -> firmware update -> begin) using any arbitrary file of around ~800kb or larger, the addon debug log shows the following:

```
2022/01/30 08:57:45 [error] 1046#1046: *4 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 172.30.32.2, server: local-zwavejs2mqtt-debug, request: "POST /socket.io/?EIO=4&transport=polling&t=NweVEQm&sid=IceD-XBENWg8zTehAABS HTTP/1.1", upstream: "http://127.0.0.1:44920/socket.io/?EIO=4&transport=polling&t=NweVEQm&sid=IceD-XBENWg8zTehAABS", host: "redacted", referrer: "https://redacted/api/hassio_ingress/nzzFjtu21sQAWNUn4KIHNzHzqiOwW49UPvG75ptbFxE/control-panel"
2022-01-30 08:57:45.142 DEBUG SOCKET: User disconnected iCOQwRO2aY6jFbDAAABT
2022-01-30 08:57:46.604 DEBUG SOCKET: New connection AV-2YjNlkZAZbFduAABV
```

However, if we adjust `/etc/nginx/servers/ingress.conf` to include Connection and Upgrade headers in the location block, the UI flashes up with `Successfully call api beginFirmwareUpdate` and the log (after manually aborting) shows:

```
2022-01-30 09:08:33.000 INFO ZWAVE: Calling api beginFirmwareUpdate with args: [
  10,
  'MultiSensor_6_AU_V1_15.exe',
  <Buffer 4d 5a 90 00 03 00 00 00 04 00 00 00 ff ff 00 00 b8 00 00 00 00 00 00 00 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... 826582 more bytes>,
  0,
  [length]: 4
]
2022-01-30T01:08:33.316Z CNTRLR » [Node 010] Starting firmware update...
2022-01-30 09:08:33.697 INFO ZWAVE: Success zwave api call beginFirmwareUpdate undefined
2022-01-30T01:08:33.874Z CNTRLR » [Node 010] Sending firmware fragment 1 / 3277
2022-01-30T01:08:34.340Z CNTRLR » [Node 010] Sending firmware fragment 2 / 3277
2022-01-30T01:08:34.812Z CNTRLR » [Node 010] Sending firmware fragment 3 / 3277
2022-01-30T01:08:35.282Z CNTRLR » [Node 010] Sending firmware fragment 4 / 3277
2022-01-30T01:08:35.753Z CNTRLR » [Node 010] Sending firmware fragment 5 / 3277
2022-01-30T01:08:36.226Z CNTRLR » [Node 010] Sending firmware fragment 6 / 3277
2022-01-30T01:08:36.691Z CNTRLR » [Node 010] Sending firmware fragment 7 / 3277
2022-01-30T01:08:37.163Z CNTRLR » [Node 010] Sending firmware fragment 8 / 3277
2022-01-30T01:08:37.632Z CNTRLR » [Node 010] Sending firmware fragment 9 / 3277
2022-01-30T01:08:38.117Z CNTRLR » [Node 010] Sending firmware fragment 10 / 3277
2022-01-30T01:08:38.571Z CNTRLR » [Node 010] Sending firmware fragment 11 / 3277
2022-01-30T01:08:39.033Z CNTRLR » [Node 010] Sending firmware fragment 12 / 3277
2022-01-30 09:08:39.274 DEBUG SOCKET: Event ZWAVE_API emitted to iETO5E9w0zsCfDTZAABg
2022-01-30 09:08:39.275 INFO ZWAVE: Calling api abortFirmwareUpdate with args: [ 10, [length]: 1 ]
2022-01-30T01:08:39.276Z CNTRLR » [Node 010] Aborting firmware update...
2022-01-30T01:08:39.979Z CNTRLR « [Node 010] Firmware update aborted
2022-01-30 09:08:39.982 INFO ZWAVE: Success zwave api call abortFirmwareUpdate undefined
2022-01-30T01:09:09.513Z CNTRLR   [Node 010] Firmware update timed out
```

The same result can be seen by either commenting out `proxy_set_header X-External-Path` from `ingress.conf`, or moving it to `includes/proxy_params.conf`.

For completeness, if left alone the firmware upgrade will complete successfully:
```
2022-01-30T04:53:54.522Z CNTRLR » [Node 010] Sending firmware fragment 3276 / 3277
2022-01-30T04:53:54.992Z CNTRLR » [Node 010] Sending firmware fragment 3277 / 3277
2022-01-30T04:54:03.621Z CNTRLR « [Node 010] Firmware update completed with status OK_RestartPending
2022-01-30T04:54:03.622Z CNTRLR   [Node 010] Firmware updated, scheduling interview in 5 seconds...
2022-01-30T04:54:08.639Z CNTRLR   [Node 010] Beginning interview - last completed stage: None
2022-01-30T04:54:08.640Z CNTRLR   [Node 010] new node, doing a full interview...
2022-01-30 12:54:08.642 INFO ZWAVE: Node 10: interview started
```

## Alternate Solutions

There were a handful of solutions I could see and I'm not sure which approach you'd favour, so this PR takes the first approach:

- Move `proxy_set_header X-External-Path` to the server context alongside `proxy_params.conf`
- Move `include /etc/nginx/includes/proxy_params.conf`  to the location context
- Move `proxy_set_header X-External-Path` into `proxy_params.conf` and update `zwavejs2mqtt/rootfs/etc/cont-init.d/nginx.sh` to template that file

Let me know what you think. Happy to open a new issue if required since the linked one was closed out due to lack of activity.

Thanks!

## Related Issues

> #51 


