### PR TITLE
⬆️ Upgrades ZwaveJS2Mqtt to v6.5.1

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -26,7 +26,7 @@ RUN \
     && npm install --global yarn@2.4.3 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v6.5.0.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v6.5.1.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
Update zwavejs2mqtt from 6.5.0 to 6.5.1

# Proposed Changes
Updates zwavejs2mqtt from 6.5.0 to 6.5.1, only minor difference

> (Describe the changes and rationale behind them)
https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v6.5.1

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
