### PR TITLE
⬆️ Upgrades zwavejs2mqtt to v6.7.2

### DIFF
--- a/zwavejs2mqtt/Dockerfile
+++ b/zwavejs2mqtt/Dockerfile
@@ -26,7 +26,7 @@ RUN \
     && npm install --global yarn@2.4.3 \
     \
     && curl -J -L -o /tmp/zwavejs2mqtt.tar.gz \
-        "https://github.com/zwave-js/zwavejs2mqtt/archive/v6.6.1.tar.gz" \
+        "https://github.com/zwave-js/zwavejs2mqtt/archive/v6.7.2.tar.gz" \
     && tar zxvf \
         /tmp/zwavejs2mqtt.tar.gz \
         --strip 1 -C /opt \
@@ -35,6 +35,8 @@ RUN \
     && yarn install --immutable \
     && yarn run build:server \
     && yarn run build:ui \
+    && npm_config_build_from_source=true \
+        yarn rebuild @serialport/bindings-cpp \
     && yarn remove \
         $(jq -r '.devDependencies | keys | join(" ")' package.json) \
     && yarn cache clean \


### PR DESCRIPTION
# Proposed Changes

Upgrades zwavejs2mqtt to v6.7.2

- https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v6.7.0
- https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v6.7.1
- https://github.com/zwave-js/zwavejs2mqtt/releases/tag/v6.7.2
