### PR TITLE
Force disable SSL

### DIFF
--- a/zwavejs2mqtt/rootfs/etc/services.d/zwavejs2mqtt/run
+++ b/zwavejs2mqtt/rootfs/etc/services.d/zwavejs2mqtt/run
@@ -9,6 +9,8 @@ export NODE_ENV=production
 export PORT=44920
 export STORE_DIR=/data/store
 export ZWAVEJS_EXTERNAL_CONFIG=/data/db
+export FORCE_DISABLE_SSL=true
+
 # Send out discovery information to Home Assistant
 ./discovery &
 


### PR DESCRIPTION
# Proposed Changes

Forcibly disables SSL for this add-on, which should address issues like #309 
There is no valid reason to enable/handle SSL inside the add-on itself on this platform, as SSL termination is handled elsewhere.


