### PR TITLE
⬆️ Update to Alpine 3.24 (base image 21.0.0)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "depNameTemplate": "alpine_3_24/{{package}}"
     },
     {
       "customType": "regex",

--- a/zwave-js-ui/Dockerfile
+++ b/zwave-js-ui/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -15,10 +15,10 @@ ARG ZWAVE_JS_UI_VERSION="11.19.1"
 RUN \
     apk add --no-cache \
         eudev=3.2.14-r6 \
-        libusb=1.0.29-r0 \
-        nginx=1.28.3-r3 \
-        nodejs=24.14.1-r0 \
-        npm=11.11.0-r0 \
+        libusb=1.0.30-r0 \
+        nginx=1.30.2-r1 \
+        nodejs=24.16.0-r0 \
+        npm=11.12.1-r0 \
     \
     && npm install \
         --no-audit \

--- a/zwave-js-ui/build.yaml
+++ b/zwave-js-ui/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:20.1.1
-  amd64: ghcr.io/hassio-addons/base:20.1.1
+  aarch64: ghcr.io/hassio-addons/base:21.0.0
+  amd64: ghcr.io/hassio-addons/base:21.0.0


### PR DESCRIPTION
# Proposed Changes

Updates the add-on to Alpine 3.24.

- Bumps the add-on base image from `20.1.1` to `21.0.0`, which is based on Alpine `3.24.0`, in both the `Dockerfile` and `build.yaml`.
- Updates the pinned `apk` packages to their latest versions for Alpine 3.24:
  - `libusb`: `1.0.29-r0` → `1.0.30-r0`
  - `nginx`: `1.28.3-r3` → `1.30.2-r1`
  - `nodejs`: `24.14.1-r0` → `24.16.0-r0`
  - `npm`: `11.11.0-r0` → `11.12.1-r0`
  - `eudev`: `3.2.14-r6` (already latest)
- Updates the Renovate Repology versioning template from `alpine_3_23` to `alpine_3_24`.

The image builds successfully with `docker build . --progress=plain --no-cache`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image dependencies from version 20.1.1 to 21.0.0
  * Upgraded bundled packages including libusb, nginx, nodejs, and npm
  * Updated Renovate configuration for Alpine package dependency tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->