### PR TITLE
📝 Remove unused forum-shield link reference from docs

### DIFF
--- a/zwave-js-ui/DOCS.md
+++ b/zwave-js-ui/DOCS.md
@@ -172,7 +172,6 @@ SOFTWARE.
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
 [esphome]: https://esphome.io/components/mqtt.html#on-message-trigger
-[forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
 [forum]: https://community.home-assistant.io/?u=frenck
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/app-zwave-js-ui/issues


### PR DESCRIPTION
# Proposed Changes

Removes the `[forum-shield]` link reference definition from `zwave-js-ui/DOCS.md`. It is leftover dead markup: the shield is never used anywhere in the document (the prose uses the `[forum]` link, not a badge). The `[forum]` reference itself is kept, as it is still used in the Support section.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an unused badge link reference from the documentation footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->