### PR TITLE
📝 Clarify the Z-Wave integration setup instructions

### DIFF
--- a/zwave-js-ui/DOCS.md
+++ b/zwave-js-ui/DOCS.md
@@ -66,9 +66,10 @@ Now it is time to set up Home Assistant:
 1. Go to the Settings panel and click "Devices & Services".
 1. In the bottom right, click "+ Add Integration".
 1. Select the "Z-Wave" integration from the list.
-1. A dialog box will show, asking to use the app:
-   - **UNCHECK** that box, it will install the official app.
-   - Again, the official app is recommended, so...
+1. A dialog box will show, asking if you want to use the Z-Wave JS
+   Supervisor app:
+   - **UNCHECK** that box, so Home Assistant does not install and use
+     its own app, but connects to this app instead.
 1. In the next dialog it will ask for the server. Enter:
    `ws://a0d7b954-zwavejs2mqtt:3000`
 1. Confirm and done!


### PR DESCRIPTION
# Proposed Changes

Clarifies the integration setup step in `zwave-js-ui/DOCS.md` that explains the dialog shown when adding the Z-Wave integration in Home Assistant.

The previous wording was self-contradictory:

> - **UNCHECK** that box, it will install the official app.
> - Again, the official app is recommended, so...

Unchecking the box is what makes Home Assistant *not* install and use its own app, so you can point it at this app's server instead. The old text said the opposite ("it will install the official app"), and the trailing "Again, the official app is recommended, so..." line was unfinished and contradicted the purpose of these instructions.

The step now states clearly what the box does and why to uncheck it.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/