### PR TITLE
📝 Drop outdated Supervisor wording from docs

### DIFF
--- a/zwave-js-ui/DOCS.md
+++ b/zwave-js-ui/DOCS.md
@@ -51,7 +51,7 @@ Home Assistant.
 To do this:
 
 1. Open the Z-Wave JS UI control panel by clicking the "OPEN WEB UI"
-   button on the app page in the Supervisor.
+   button on the app page.
 1. In the control panel, go to "Settings" in the menu and click on the "Zwave"
    bar that shows up on the right.
 1. Enter the following information:


### PR DESCRIPTION
# Proposed Changes

Removes the outdated "in the Supervisor" phrasing from the "OPEN WEB UI" step in `zwave-js-ui/DOCS.md`. The Supervisor is no longer surfaced as a place users navigate to; the app page is reached directly from Settings, so "on the app page" is accurate and sufficient.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/