### PR TITLE
📝 Remove chat and community forum badges from add-on README

### DIFF
--- a/zwave-js-ui/.README.j2
+++ b/zwave-js-ui/.README.j2
@@ -2,8 +2,6 @@
 
 [![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
 
-[![Discord][discord-shield]][discord] [![Community Forum][forum-shield]][forum]
-
 [![Sponsor Frenck via GitHub Sponsors][github-sponsors-shield]][github-sponsors]
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
@@ -70,11 +68,7 @@ If you are more interested in stable releases of our apps:
 <https://github.com/hassio-addons/repository>
 
 {% endif %}
-[discord-shield]: https://img.shields.io/discord/478094546522079232.svg
-[discord]: https://discord.me/hassioaddons
 [esphome]: https://esphome.io/components/mqtt.html#on-message-trigger
-[forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
-[forum]: https://community.home-assistant.io/?u=frenck
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
 [logo]: https://github.com/hassio-addons/app-zwave-js-ui/raw/main/zwave-js-ui/logo.png


### PR DESCRIPTION
# Proposed Changes

Removes the Discord (chat) and Community Forum badges from the add-on README template (`zwave-js-ui/.README.j2`), which generates the README shown on the add-on's info page in the Home Assistant store.

These badges were already removed from the top-level repository `README.md` in #905, but the add-on README template was missed, so the badges still rendered there. This completes that cleanup. The now-unused `discord-shield`, `discord`, `forum-shield`, and `forum` link references are removed as well; they were not used anywhere else in the template.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Discord and Community Forum shield badges from the README.
  * Reorganized reference link definitions in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->