### PR TITLE
🔥 Remove non-functional log_level option

### DIFF
--- a/zwave-js-ui/DOCS.md
+++ b/zwave-js-ui/DOCS.md
@@ -73,34 +73,6 @@ Now it is time to set up Home Assistant:
    `ws://a0d7b954-zwavejs2mqtt:3000`
 1. Confirm and done!
 
-## Configuration
-
-**Note**: _Remember to restart the app when the configuration is changed._
-
-Example app configuration:
-
-```yaml
-log_level: info
-```
-
-### Option: `log_level`
-
-The `log_level` option controls the level of log output by the app and can
-be changed to be more or less verbose, which might be useful when you are
-dealing with an unknown issue. Possible values are:
-
-- `trace`: Show every detail, like all called internal functions.
-- `debug`: Shows detailed debug information.
-- `info`: Normal (usually) interesting events.
-- `warning`: Exceptional occurrences that are not errors.
-- `error`: Runtime errors that do not require immediate action.
-- `fatal`: Something went terribly wrong. App becomes unusable.
-
-Please note that each level automatically includes log messages from a
-more severe level, e.g., `debug` also shows `info` messages. By default,
-the `log_level` is set to `info`, which is the recommended setting unless
-you are troubleshooting.
-
 ## Known issues and limitations
 
 - Z-Wave JS UI supports Home Assistant Discovery over MQTT. It is

--- a/zwave-js-ui/config.yaml
+++ b/zwave-js-ui/config.yaml
@@ -22,8 +22,6 @@ uart: true
 udev: true
 map:
   - share:rw
-schema:
-  log_level: list(trace|debug|info|notice|warning|error|fatal)?
 ports:
   3000/tcp: null
 ports_description:

--- a/zwave-js-ui/translations/en.yaml
+++ b/zwave-js-ui/translations/en.yaml
@@ -1,8 +1,3 @@
 ---
-configuration:
-  log_level:
-    name: Log level
-    description: >-
-      Controls the level of log details the app provides.
 network:
   3000/tcp: Z-Wave JS server port


### PR DESCRIPTION
# Proposed Changes

Removes the `log_level` add-on option, which never did anything.

The option was defined in `config.yaml`, documented in `DOCS.md`, and translated in `translations/en.yaml`, but no script ever read it: `bashio::config 'log_level'` is not called anywhere, and `init-zwave-js-ui/run` hardcodes `logLevel info` in the seeded `settings.json`. So changing the option had no effect.

Wiring it up is not worthwhile either: the add-on's declared levels (`trace`, `notice`, `warning`, `fatal`) are not valid Z-Wave JS UI / node-zwave-js log levels (which are `error`, `warn`, `info`, `http`, `verbose`, `debug`, `silly`), and `settings.json` is only seeded on first run, after which logging is managed in the Z-Wave JS UI itself.

This removes:
- The `schema.log_level` entry (and now-empty `schema` block) from `config.yaml`.
- The `configuration.log_level` entry from `translations/en.yaml`.
- The `Configuration` / `Option: log_level` section from `DOCS.md` (it was the only option, so the section is gone entirely).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the logging level configuration option, including documentation, validation schema, and language translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->