### PR TITLE
📝 Fix grammar in discovery success log message

### DIFF
--- a/zwave-js-ui/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
+++ b/zwave-js-ui/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
@@ -20,7 +20,7 @@ payload=$(\
 )
 
 if bashio::discovery "zwave_js" "${payload}" > /dev/null; then
-    bashio::log.info "Successfully send discovery information to Home Assistant."
+    bashio::log.info "Successfully sent discovery information to Home Assistant."
 else
     bashio::log.error "Discovery message to Home Assistant failed!"
 fi


### PR DESCRIPTION
# Proposed Changes

Fixes a small grammar mistake in the discovery service log message: "Successfully send discovery information to Home Assistant." becomes "Successfully sent discovery information to Home Assistant."

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/