### PR TITLE
🔥 Remove unused nginx ssl_params.conf

### DIFF
--- a/zwave-js-ui/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/zwave-js-ui/rootfs/etc/nginx/includes/ssl_params.conf
@@ -1,8 +1,0 @@
-ssl_protocols TLSv1.2 TLSv1.3;
-ssl_prefer_server_ciphers off;
-ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-ssl_session_timeout  10m;
-ssl_session_cache shared:SSL:10m;
-ssl_session_tickets off;
-ssl_stapling on;
-ssl_stapling_verify on;


### PR DESCRIPTION
# Proposed Changes

Removes `zwave-js-ui/rootfs/etc/nginx/includes/ssl_params.conf`, which is never used.

The only server block in this app is the ingress block generated from `ingress.gtpl`, which listens on plain HTTP (`:8099`) and includes only `server_params.conf` and `proxy_params.conf`. TLS is terminated upstream by the Home Assistant ingress proxy, so there is no `listen ... ssl` directive anywhere, and nothing includes `ssl_params.conf`. The file shipped but was never loaded.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/