### PR TITLE
🔒 Disable legacy X-XSS-Protection filter

### DIFF
--- a/zwave-js-ui/rootfs/etc/nginx/includes/server_params.conf
+++ b/zwave-js-ui/rootfs/etc/nginx/includes/server_params.conf
@@ -2,5 +2,5 @@ root            /dev/null;
 server_name     $hostname;
 
 add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";
+add_header X-XSS-Protection "0";
 add_header X-Robots-Tag none;


### PR DESCRIPTION
# Proposed Changes

Changes the `X-XSS-Protection` response header from `1; mode=block` to `0` in the nginx `server_params.conf`.

The legacy XSS auditor this header enables has been removed from all modern browsers, and where it is still honored (older browsers) it can introduce vulnerabilities of its own. Current guidance (OWASP Secure Headers project) is to explicitly disable it with `X-XSS-Protection: 0` rather than enabling the filter, while relying on a proper Content Security Policy instead.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/